### PR TITLE
Make output state closer to minimal

### DIFF
--- a/crypto.js
+++ b/crypto.js
@@ -96,12 +96,12 @@ exports.clean = function (state) {
   state.secret3.fill(0)
   state.local.kx_sk.fill(0)
 
-  state.shash = null
-  state.secret2 = null
-  state.secret3 = null
-  state.a_bob = null
-  state.b_alice = null
-  state.local.kx_sk = null
+  delete state.shash
+  delete state.secret2
+  delete state.secret3
+  delete state.a_bob
+  delete state.b_alice
+  delete state.local.kx_sk
   return state
 }
 

--- a/crypto.js
+++ b/crypto.js
@@ -183,9 +183,5 @@ exports.serverCreateAccept = function (state) {
 }
 
 exports.toKeys = function (keys) {
-  if(isBuffer(keys, 32))
-    return sodium.crypto_sign_seed_keypair(keys)
-  return keys
+  return (isBuffer(keys, 32)) ? from_seed(keys) : keys
 }
-
-


### PR DESCRIPTION
Sensitive properties of the state should be deleted instead only being nullified. This helps to minimalize test vectors.