### PR TITLE
Update chloride to 2.2.6

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -112,9 +112,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "chloride": {
-      "version": "2.2.4",
+      "version": "2.2.6",
       "from": "chloride@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.4.tgz"
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.6.tgz"
     },
     "chloride-test": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/dominictarr/secret-handshake.git"
   },
   "dependencies": {
-    "chloride": "^2.0.1",
+    "chloride": "^2.2.6",
     "deep-equal": "~1.0.0",
     "pull-box-stream": "^1.0.9",
     "pull-handshake": "^1.1.1",


### PR DESCRIPTION
The important part was updating the shrinkwrap file, because the package.json field should anyway according to semver wish for 2.2.6 even if it was ^2.0.1.