### PR TITLE
change from new Buffer > Buffer.from or Buffer.alloc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/crypto.js
+++ b/crypto.js
@@ -1,7 +1,6 @@
 'use strict'
 var sodium      = require('chloride')
 
-var keypair     = sodium.crypto_box_seed_keypair
 var from_seed   = sodium.crypto_sign_seed_keypair
 var shared      = sodium.crypto_scalarmult
 var hash        = sodium.crypto_hash_sha256
@@ -16,7 +15,7 @@ var unbox       = sodium.crypto_secretbox_open_easy
 
 var concat = Buffer.concat
 
-var nonce = new Buffer(24); nonce.fill(0)
+var nonce = Buffer.alloc(24); nonce.fill(0)
 
 var isBuffer = Buffer.isBuffer
 

--- a/random.js
+++ b/random.js
@@ -2,7 +2,7 @@
 var cl = require('chloride')
 
 module.exports = function (bytes) {
-  var b = new Buffer(bytes)
+  var b = Buffer.alloc(bytes)
   cl.randombytes(b, bytes)
   return b
 }

--- a/test/net1.js
+++ b/test/net1.js
@@ -6,7 +6,7 @@ var tape = require('tape')
 
 var cl = require('chloride')
 function hash (str) {
-  return cl.crypto_hash_sha256(new Buffer(str))
+  return cl.crypto_hash_sha256(Buffer.from(str))
 }
 
 var alice = cl.crypto_sign_seed_keypair(hash('alice'))
@@ -51,11 +51,11 @@ tape('test with net', function (t) {
       createClient(bob.publicKey, function (err, stream) {
         console.log('client connected', err, stream)
         pull(
-          pull.values([new Buffer('HELLO')]),
+          pull.values([Buffer.from('HELLO')]),
           stream,
           pull.collect(function (err, data) {
             t.notOk(err)
-            t.deepEqual(Buffer.concat(data), new Buffer('HELLO'))
+            t.deepEqual(Buffer.concat(data), Buffer.from('HELLO'))
             server.close()
             t.end()
           })

--- a/test/net2.js
+++ b/test/net2.js
@@ -8,7 +8,7 @@ var tape = require('tape')
 var cl = require('chloride')
 
 function hash (str) {
-  return cl.crypto_hash_sha256(new Buffer(str))
+  return cl.crypto_hash_sha256(Buffer.from(str))
 }
 
 var alice = cl.crypto_sign_seed_keypair(hash('alice'))
@@ -50,12 +50,12 @@ tape('test net.js, correct, callback', function (t) {
         if(err) throw err
         t.deepEqual(stream.remote, bob.publicKey)
         pull(
-          pull.values([new Buffer('HELLO')]),
+          pull.values([Buffer.from('HELLO')]),
           stream,
           pull.collect(function (err, data) {
             if(err) throw err
             t.notOk(err)
-            t.deepEqual(Buffer.concat(data), new Buffer('HELLO'))
+            t.deepEqual(Buffer.concat(data), Buffer.from('HELLO'))
             server.close()
             t.end()
           })
@@ -73,12 +73,12 @@ tape('test net.js, correct, stream directly', function (t) {
     pull(stream, pull.through(console.log), stream) //echo
   }).listen(PORT, function () {
     pull(
-      pull.values([new Buffer('HELLO')]),
+      pull.values([Buffer.from('HELLO')]),
       aliceN.connect({port: PORT, key: bob.publicKey}),
       pull.collect(function (err, data) {
         if(err) throw err
         t.notOk(err)
-        t.deepEqual(Buffer.concat(data), new Buffer('HELLO'))
+        t.deepEqual(Buffer.concat(data), Buffer.from('HELLO'))
         server.close()
         t.end()
       })

--- a/test/secret-handshake.js
+++ b/test/secret-handshake.js
@@ -10,7 +10,7 @@ var bitflipper = require('pull-bitflipper')
 var Hang = require('pull-hang')
 
 function hash (str) {
-  return cl.crypto_hash_sha256(new Buffer(str))
+  return cl.crypto_hash_sha256(Buffer.from(str))
 }
 
 var alice = cl.crypto_sign_seed_keypair(hash('alice'))
@@ -37,7 +37,7 @@ tape('test handshake', function (t) {
       if(err) throw err
 
       pull(
-        pull.values([new Buffer('hello there')]),
+        pull.values([Buffer.from('hello there')]),
         stream,
         pull.collect(function (err, hello_there) {
           t.equal(hello_there.toString(), 'hello there')


### PR DESCRIPTION
I was running the tests and seeing warnings about `new Buffer`being deprecated and there being potential security problems with it.

This PR aims to fix that